### PR TITLE
Updated pg peer to 6.x versions to squash npm warning on newer versions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/Madadata/winston-pg#readme",
   "peerDependencies": {
     "winston": "^2.2.0",
-    "pg": "^4.5.6"
+    "pg": ">=4.5.6 <=6.x"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",


### PR DESCRIPTION
I've only tested up to 6.x but would probably work through 7 